### PR TITLE
New: Coach Retail Japan Theme

### DIFF
--- a/src/brands/coach/japan/font/face.json
+++ b/src/brands/coach/japan/font/face.json
@@ -1,0 +1,43 @@
+{
+  "font": {
+    "face": {
+      "1": {
+        "normal": {
+          "family": {
+            "value": "Source Han Sans Regular"
+          },
+          "local": {
+            "value": ["SourceHanSans-Regular"]
+          },
+          "woff2": {
+            "value": "https://assets.coach.com/jp/fonts/SourceHanSans-Regular.woff2"
+          }
+        },
+        "bold": {
+          "family": {
+            "value": "Source Han Sans Heavy"
+          },
+          "local": {
+            "value": ["SourceHanSans-Heavy"]
+          },
+          "woff2": {
+            "value": "https://assets.coach.com/jp/fonts/SourceHanSans-Heavy.woff2"
+          }
+        }
+      },
+      "2": {
+        "normal": {
+          "family": {
+            "value": "Source Han Serif Regular"
+          },
+          "local": {
+            "value": ["SourceHanSerif-Regular"]
+          },
+          "woff2": {
+            "value": "https://assets.coach.com/jp/fonts/SourceHanSerif-Regular.woff2"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/brands/coach/japan/size/letter-spacing.json
+++ b/src/brands/coach/japan/size/letter-spacing.json
@@ -1,0 +1,24 @@
+{
+  "size": {
+    "letter-spacing": {
+      "xs": {
+        "value": "-0.2px"
+      },
+      "s": {
+        "value": "0px"
+      },
+      "m": {
+        "value": "0.2px"
+      },
+      "l": {
+        "value": "0.4px"
+      },
+      "xl": {
+        "value": "1px"
+      },
+      "2xl": {
+        "value": "1.25px"
+      }
+    }
+  }
+}

--- a/src/brands/coach/japan/size/line-height.json
+++ b/src/brands/coach/japan/size/line-height.json
@@ -1,0 +1,30 @@
+{
+  "size": {
+    "line-height": {
+      "xs": {
+        "value": "{size.line-height.100.value}"
+      },
+      "s": {
+        "value": "{size.line-height.115.value}"
+      },
+      "xl": {
+        "value": "{size.line-height.150.value}"
+      },
+      "2xl": {
+        "value": "{size.line-height.175.value}"
+      },
+      "100": {
+        "value": "1"
+      },
+      "115": {
+        "value": "1.15"
+      },
+      "150": {
+        "value": "1.5"
+      },
+      "175": {
+        "value": "1.75"
+      }
+    }
+  }
+}

--- a/src/brands/coach/japan/utility/typography.json
+++ b/src/brands/coach/japan/utility/typography.json
@@ -1,0 +1,166 @@
+{
+  "utility": {
+    "typography": {
+      "display1": {
+        "xs": {
+          "line-height": {
+            "value": "{size.line-height.l.value}"
+          }
+        },
+        "s": {
+          "line-height": {
+            "value": "{size.line-height.l.value}"
+          }
+        },
+        "m": {
+          "line-height": {
+            "value": "{size.line-height.m.value}"
+          }
+        },
+        "l": {
+          "line-height": {
+            "value": "{size.line-height.m.value}"
+          }
+        },
+        "xl": {
+          "line-height": {
+            "value": "{size.line-height.m.value}"
+          }
+        },
+        "2xl": {
+          "line-height": {
+            "value": "{size.line-height.m.value}"
+          }
+        }
+      },
+      "display2": {
+        "xs": {
+          "line-height": {
+            "value": "{size.line-height.l.value}"
+          }
+        },
+        "s": {
+          "line-height": {
+            "value": "{size.line-height.m.value}"
+          }
+        },
+        "m": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.s.value}"
+          },
+          "line-height": {
+            "value": "{size.line-height.m.value}"
+          }
+        },
+        "l": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.s.value}"
+          },
+          "line-height": {
+            "value": "{size.line-height.m.value}"
+          }
+        },
+        "xl": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.s.value}"
+          },
+          "line-height": {
+            "value": "{size.line-height.m.value}"
+          }
+        },
+        "2xl": {
+          "line-height": {
+            "value": "{size.line-height.m.value}"
+          }
+        }
+      },
+      "body1": {
+        "xs": {
+          "font-size": {
+            "value": "{size.font.10.value}"
+          },
+          "letter-spacing": {
+            "value": "{size.letter-spacing.l.value}"
+          }
+        },
+        "s": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.m.value}"
+          },
+          "line-height": {
+            "value": "{size.line-height.2xl.value}"
+          }
+        },
+        "m": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.m.value}"
+          },
+          "line-height": {
+            "value": "{size.line-height.2xl.value}"
+          }
+        },
+        "l": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.m.value}"
+          },
+          "line-height": {
+            "value": "{size.line-height.xl.value}"
+          }
+        }
+      },
+      "body2": {
+        "s": {
+          "font-size": {
+            "value": "{size.font.12.value}"
+          },
+          "letter-spacing": {
+            "value": "{size.letter-spacing.m.value}"
+          },
+          "line-height": {
+            "value": "{size.line-height.2xl.value}"
+          }
+        },
+        "m": {
+          "font-size": {
+            "value": "{size.font.14.value}"
+          },
+          "letter-spacing": {
+            "value": "{size.letter-spacing.m.value}"
+          }
+        },
+        "l": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.m.value}"
+          }
+        }
+      },
+      "label1": {
+        "m": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.xl.value}"
+          },
+          "line-height": {
+            "value": "{size.line-height.s.value}"
+          }
+        }
+      },
+      "cta1": {
+        "l": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.2xl.value}"
+          }
+        },
+        "m": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.2xl.value}"
+          }
+        },
+        "s": {
+          "letter-spacing": {
+            "value": "{size.letter-spacing.2xl.value}"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
src/brands/coach/japan/font/face.json
> - Added the overrides of the 3 fonts.  Source Han Sans Regular, Source Han Sans Heavy, and Source Han Serif Regular.
---
src/brands/coach/japan/size/letter-spacing.json
> - Added the letter-spacing overrides for xs, s, m, l, xl, and 2xl.
---
src/brands/coach/japan/size/line-height.json
> - Added the line-height overrides for xs, s, xl, and 2xl.
> - Added new definitions for 100, 115, 150, and 175 that did not exist before.
---
src/brands/coach/japan/utility/typography.json
> - Added overrides for display1, display2, body1, body2, label1, and cta1 to use different line-height and letter-spacing values.
---

![Screen Shot 2022-05-17 at 3 39 52 PM](https://user-images.githubusercontent.com/97971327/168901982-aa0906e1-efc3-4fe9-ab13-d9ab09c6f679.png)
