### PR TITLE
Fix: Coach Outlet Japan Extended Bold Font

### DIFF
--- a/src/brands/coach-outlet/japan/font/face.json
+++ b/src/brands/coach-outlet/japan/font/face.json
@@ -130,9 +130,9 @@
         }
       },
       "5": {
-        "bold": {
+        "extended-bold": {
           "family": {
-            "value": "Neue Helvetica Bold"
+            "value": "Neue Helvetica Extended Bold"
           },
           "style": {
             "value": "normal"
@@ -144,10 +144,10 @@
             "value": "normal"
           },
           "local": {
-            "value": ["NeueHelvetica75Bold"]
+            "value": ["NeueHelvetica73ExtendedBold"]
           },
           "woff2": {
-            "value": "https://assets.coach.com/jp/fonts/NeueHelvetica75Bold.woff2"
+            "value": "https://assets.coach.com/jp/fonts/NeueHelvetica73ExtendedBold.woff2"
           }
         }
       }

--- a/src/brands/coach-outlet/japan/font/family.json
+++ b/src/brands/coach-outlet/japan/font/family.json
@@ -15,8 +15,8 @@
         }
       },
       "face3": {
-        "bold": {
-          "value": "{font.face.5.bold.family.value}, Helvetica, Arial, sans-serif"
+        "extended-bold": {
+          "value": "{font.face.5.extended-bold.family.value}, Helvetica, Arial, sans-serif"
         }
       }
     }


### PR DESCRIPTION
src/brands/coach-outlet/japan/font/face.json
> - Changed font 5 from bold to extended-bold.
> - Changed font 5 from NeueHelvetica75Bold to NeueHelvetica73ExtendedBold.
---
src/brands/coach-outlet/japan/font/family.json
> - Changed font-face3 from bold to extended-bold.
---